### PR TITLE
Select the correct database before evaluating CORS

### DIFF
--- a/lib/hitobito_tenants/wagon.rb
+++ b/lib/hitobito_tenants/wagon.rb
@@ -37,7 +37,7 @@ module HitobitoTenants
       require 'apartment/elevators/main_subdomain'
       require 'hitobito_tenants/apartment'
 
-      Rails.application.config.middleware.insert_before Rails::Rack::Logger,
+      Rails.application.config.middleware.insert_before Rack::Cors,
                                                         Apartment::Elevators::MainSubdomain
     end
 


### PR DESCRIPTION
https://help.puzzle.ch/#ticket/zoom/3220
Löst ein Middleware-Reihenfolge-Problem. Für CORS verwenden wir https://github.com/cyu/rack-cors, welches empfiehlt, sich möglichst früh in der Middleware-Queue einzuhängen (insert_before 0), insbesondere aber vor Caching-Middlewares. Für die Multitenancy verwenden wir eine custom Middleware basierend auf https://github.com/influitive/apartment, welche die Datenbank die zur Subdomain passt auswählt. In der CORS Middleware greifen wir aber auf die Datenbank zu.

Lösung ist, die Multitenancy-Middleware vor der CORS-Middleware auszuführen (also früher als bisher). Der neue Stack sieht dann ungefähr so aus:
```
use PrometheusExporter::Middleware
use Apartment::Elevators::MainSubdomain
use Rack::Cors
use Raven::Rack
use ActionDispatch::HostAuthorization
use Rack::Sendfile
use ActionDispatch::Executor
use ActiveSupport::Cache::Strategy::LocalCache::Middleware
use Rack::Runtime
use Rack::MethodOverride
use ActionDispatch::RequestId
use RequestStore::Middleware
use ActionDispatch::RemoteIp
use Rails::Rack::Logger
use ActionDispatch::ShowExceptions
use ActionDispatch::DebugExceptions
use Airbrake::Rack::Middleware
use ActionDispatch::ActionableExceptions
use ActionDispatch::Callbacks
use ActionDispatch::Cookies
use ActionDispatch::Session::ActiveRecordStore
use ActionDispatch::Flash
use ActionDispatch::ContentSecurityPolicy::Middleware
use Rack::Head
use Rack::ConditionalGet
use Rack::Deflater
use Rack::ETag
use Rack::TempfileReaper
use Warden::Manager
use Remotipart::Middleware
use HttpAcceptLanguage::Middleware
run Hitobito::Application.routes
```