### PR TITLE
Implement multitenant domain switching for the new mail stack

### DIFF
--- a/app/domain/tenants/mailing_lists/bulk_mail/retriever.rb
+++ b/app/domain/tenants/mailing_lists/bulk_mail/retriever.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2023, Hitobito AG. This file is part of
+# hitobito_tenants and licensed under the Affero General Public License version 3
+# or later. See the COPYING file at the top-level directory or at
+# https://github.com/hitobito/hitobito_tenants.
+
+module Tenants::MailingLists::BulkMail::Retriever
+  extend ActiveSupport::Concern
+
+  private
+
+  def process_valid_mail(imap_mail, mail_log, validator)
+    host = envelope_host_name(imap_mail)
+    database = Apartment::Elevators::MainSubdomain.new(nil).tenant_database(host)
+    if database
+      Apartment::Tenant.switch(database) { super }
+    else
+      mail_log.destroy!
+      logger.info("Ignored email from #{imap_mail.sender_email} for unknown tenant #{host}")
+    end
+  end
+
+  # The receiver subdomain that originally got this email.
+  # Returns only the first part after the @ sign
+  def envelope_host_name(imap_mail)
+    receiver_host_from_sender_email(imap_mail) ||
+      raise("Could not determine original receiver tenant for email:\n#{imap_mail.header}")
+  end
+
+  def receiver_host_from_sender_email(imap_mail)
+    imap_mail.original_to.to_s.split('@', 2).last.presence
+  end
+end

--- a/lib/hitobito_tenants/wagon.rb
+++ b/lib/hitobito_tenants/wagon.rb
@@ -26,6 +26,7 @@ module HitobitoTenants
       BaseJob.prepend Tenants::BaseJob
       ApplicationMailer.include Tenants::DynamicUrlHost
       MailRelay::Lists.prepend Tenants::MailRelay::Lists
+      MailingLists::BulkMail::Retriever.prepend Tenants::MailingLists::BulkMail::Retriever
 
       Ability.prepend Tenants::Ability
       Ability.store.register TenantAbility

--- a/spec/domain/mailing_lists/bulk_mail/retriever_spec.rb
+++ b/spec/domain/mailing_lists/bulk_mail/retriever_spec.rb
@@ -1,0 +1,113 @@
+# encoding: utf-8
+
+#  Copyright (c) 2023, hitobito AG. This file is part of
+#  hitobito_tenants and licensed under the Affero General Public License version 3
+#  or later. See the COPYING file at the top-level directory or at
+#  https://github.com/hitobito/hitobito_tenants.
+
+require 'spec_helper'
+
+describe MailingLists::BulkMail::Retriever do
+  include MailingLists::ImapMailsSpecHelper
+
+  let(:retriever) { described_class.new }
+  let(:imap_connector) { instance_double(Imap::Connector) }
+  let(:mailing_list) { mailing_lists(:leaders) }
+  let(:imap_mail_validator) { instance_double(MailingLists::BulkMail::ImapMailValidator) }
+  let(:imap_mail) { build_imap_mail(42) }
+  let(:dispatch_job) { instance_double(Messages::DispatchJob) }
+
+  let(:original_to) { "#{list.mail_name}@#{envelope_host}.#{Settings.tenants.domain.gsub(/:[0-9]+$/, '')}" }
+  let(:from) { people(:top_leader).email }
+
+  let(:bll)  { people(:bottom_leader) }
+  let(:bgl1) { Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_one)).person }
+  let(:bgl2) { Fabricate(Group::BottomGroup::Leader.name.to_sym, group: groups(:bottom_group_one_two)).person }
+  let(:ind)  { Fabricate(:person) }
+
+  let(:list) { mailing_lists(:leaders) }
+
+  let(:subscribers) { [ind, bll, bgl1] }
+
+  subject { retriever }
+
+  before do
+    create_individual_subscribers
+    allow(retriever).to receive(:validator).and_return(imap_mail_validator)
+    allow(retriever).to receive(:imap).and_return(imap_connector)
+    allow(imap_connector).to receive(:fetch_mail_by_uid).with(42, :inbox).and_return(imap_mail)
+    allow(imap_connector).to receive(:fetch_mail_uids).with(:inbox).and_return([42])
+    allow(imap_connector).to receive(:delete_by_uid).with(42, :inbox).and_return(nil)
+    allow(imap_mail_validator).to receive(:valid_mail?).and_return(true)
+    allow(imap_mail_validator).to receive(:processed_before?).and_return(false)
+    allow(imap_mail_validator).to receive(:sender_allowed?).and_return(true)
+  end
+
+  context 'to admin tenant' do
+
+    let(:envelope_host) { 'admin' }
+
+    it 'retrieves and schedules sender job' do
+      expect(Apartment::Tenant).to receive(:switch).with(Apartment::Tenant.default_tenant).and_yield
+      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job)
+      expect(dispatch_job).to receive(:enqueue!).and_return nil
+
+      expect { subject.perform }.to change { MailLog.count }.by(1)
+    end
+
+  end
+
+  context 'to custom tenant' do
+
+    let(:envelope_host) { 'test-tenant' }
+
+    it 'retrieves and schedules sender job' do
+      expect(Apartment::Tenant).to receive(:switch).with('test-tenant').and_yield
+      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job)
+      expect(dispatch_job).to receive(:enqueue!).and_return nil
+
+      expect { subject.perform }.to change { MailLog.count }.by(1)
+    end
+
+  end
+
+  context 'to non-existing tenant' do
+
+    let(:envelope_host) { 'unknown-tenant' }
+
+    it 'does not do anything' do
+      expect(Messages::DispatchJob).not_to receive(:new)
+      expect { subject.perform }.not_to change { MailLog.count }
+    end
+
+  end
+
+
+  def create_individual_subscribers
+    # single subscription
+    sub = list.subscriptions.new
+    sub.subscriber = ind
+    sub.save!
+    # excluded subscription
+    sub = list.subscriptions.new
+    sub.subscriber = bgl2
+    sub.excluded = true
+    sub.save!
+
+    # create people
+    subscribers
+  end
+
+  def build_imap_mail(uid)
+    mail = Imap::Mail.new
+    allow(mail).to receive(:uid).and_return(uid)
+    allow(mail).to receive(:subject).and_return('Mail 42')
+    allow(mail).to receive(:original_to).and_return(original_to)
+    allow(mail).to receive(:hash).and_return('abcd42')
+    allow(mail).to receive(:sender_email).and_return(from)
+
+    imap_mail = Mail.read_from_string(File.read(Rails.root.join('spec', 'fixtures', 'email', 'list.eml')))
+    allow(mail).to receive(:mail).and_return(imap_mail)
+    mail
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,7 @@ Dir[HitobitoTenants::Wagon.root.join('spec/support/**/*.rb')].sort.each { |f| re
 RSpec.configure do |config|
   config.fixture_path = File.expand_path('../fixtures', __FILE__)
 
-  config.before(:suite) { Tenant.create!(name: 'test-tenant') }
+  config.before(:suite) { Tenant.find_or_create_by(name: 'test-tenant') }
 
   config.before { Apartment.default_tenant = Apartment::Tenant.current }
 end


### PR DESCRIPTION
Copied and adapted the extra logic for switching the database based on the receiver address on the received email, from here: https://github.com/hitobito/hitobito_tenants/blob/master/app/domain/tenants/mail_relay/lists.rb#L13

Fixes https://help.puzzle.ch/#ticket/zoom/5748