### PR TITLE
Wrap process_mail inside correct tenant db

### DIFF
--- a/app/domain/tenants/mailing_lists/bulk_mail/retriever.rb
+++ b/app/domain/tenants/mailing_lists/bulk_mail/retriever.rb
@@ -10,13 +10,14 @@ module Tenants::MailingLists::BulkMail::Retriever
 
   private
 
-  def process_valid_mail(imap_mail, mail_log, validator)
+  def process_mail(mail_uid)
+    imap_mail = fetch_mail(mail_uid)
+
     host = envelope_host_name(imap_mail)
     database = Apartment::Elevators::MainSubdomain.new(nil).tenant_database(host)
     if database
       Apartment::Tenant.switch(database) { super }
     else
-      mail_log.destroy!
       logger.info("Ignored email from #{imap_mail.sender_email} for unknown tenant #{host}")
     end
   end

--- a/spec/domain/mailing_lists/bulk_mail/retriever_spec.rb
+++ b/spec/domain/mailing_lists/bulk_mail/retriever_spec.rb
@@ -48,9 +48,11 @@ describe MailingLists::BulkMail::Retriever do
     let(:envelope_host) { 'admin' }
 
     it 'retrieves and schedules sender job' do
-      expect(Apartment::Tenant).to receive(:switch).with(Apartment::Tenant.default_tenant).and_yield
-      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job)
-      expect(dispatch_job).to receive(:enqueue!).and_return nil
+      expect(Apartment::Tenant).to receive(:switch).with(Apartment::Tenant.default_tenant).ordered.and_yield
+      expect(Message::BulkMail).to receive(:create!).ordered.and_call_original
+      expect(MailLog).to receive(:create!).ordered.and_call_original
+      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job).ordered
+      expect(dispatch_job).to receive(:enqueue!).ordered.and_return nil
 
       expect { subject.perform }.to change { MailLog.count }.by(1)
     end
@@ -62,9 +64,11 @@ describe MailingLists::BulkMail::Retriever do
     let(:envelope_host) { 'test-tenant' }
 
     it 'retrieves and schedules sender job' do
-      expect(Apartment::Tenant).to receive(:switch).with('test-tenant').and_yield
-      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job)
-      expect(dispatch_job).to receive(:enqueue!).and_return nil
+      expect(Apartment::Tenant).to receive(:switch).with('test-tenant').ordered.and_yield
+      expect(Message::BulkMail).to receive(:create!).ordered.and_call_original
+      expect(MailLog).to receive(:create!).ordered.and_call_original
+      expect(Messages::DispatchJob).to receive(:new).and_return(dispatch_job).ordered
+      expect(dispatch_job).to receive(:enqueue!).and_return(nil).ordered
 
       expect { subject.perform }.to change { MailLog.count }.by(1)
     end


### PR DESCRIPTION
Leider war bei #12 noch ein Denkfehler drin, dass nicht die richtige Methode gewrapped wurde.
Dadurch wurden der `MailLog` und `Message::BulkMail` Record jeweils noch in der falschen DB angelegt und konnten dann nicht mehr gefunden werden.