### PR TITLE
Remove jobs queued for tenant when destroying tenant

### DIFF
--- a/app/jobs/tenant_destroyer_job.rb
+++ b/app/jobs/tenant_destroyer_job.rb
@@ -16,5 +16,6 @@ class TenantDestroyerJob < BaseJob
     return if Tenant.where(name: name).exists?
 
     Apartment::Tenant.drop(name)
+    Delayed::Job.where(tenant: name).delete_all
   end
 end


### PR DESCRIPTION
Without this, jobs queued for the tenant stay queued and will raise an exception when a worker tries to pick them up:
```ruby
Caused by:
ActiveRecord::StatementInvalid: Could not find schema ${tenant_name} (ActiveRecord::StatementInvalid)
```
This causes the workers to crash-loop